### PR TITLE
1.2.0 Build for arm64 platforms

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -57,6 +57,16 @@ jobs:
           asset_name: pam-keycloak-oidc.linux-amd64
           asset_content_type: application/octet-stream
       -
+        name: Upload Release Asset (Linux arm64)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./pam-keycloak-oidc.linux-arm64
+          asset_name: pam-keycloak-oidc.linux-arm64
+          asset_content_type: application/octet-stream
+      -
         name: Upload Release Asset (macOS amd64)
         uses: actions/upload-release-asset@v1
         env:
@@ -67,6 +77,16 @@ jobs:
           asset_name: pam-keycloak-oidc.macOS-intel
           asset_content_type: application/octet-stream
       -
+        name: Upload Release Asset (macOS arm64)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./pam-keycloak-oidc.darwin-arm64
+          asset_name: pam-keycloak-oidc.macOS-arm64
+          asset_content_type: application/octet-stream
+      -
         name: Upload Release Asset (Windows amd64)
         uses: actions/upload-release-asset@v1
         env:
@@ -74,5 +94,15 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           asset_path: ./pam-keycloak-oidc.windows-amd64.exe
-          asset_name: pam-keycloak-oidc.exe
+          asset_name: pam-keycloak-oidc-amd64.exe
+          asset_content_type: application/octet-stream
+      -
+        name: Upload Release Asset (Windows arm64)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./pam-keycloak-oidc.windows-arm64.exe
+          asset_name: pam-keycloak-oidc-arm64.exe
           asset_content_type: application/octet-stream

--- a/.scmi-bumpversion.cfg
+++ b/.scmi-bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.6
+current_version = 1.2.0
 commit = True
 tag = False
 

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ K := $(foreach exec,$(EXECUTABLES),\
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 BINARY=pam-keycloak-oidc
-VERSION=1.1.6
+VERSION=1.2.0
 BUILD=`git rev-parse HEAD`
 PLATFORMS=darwin linux windows
-ARCHITECTURES=amd64
+ARCHITECTURES=amd64 arm64
 
 # Setup linker flags option for build that inter-operate with variable names in src code
 LDFLAGS=-ldflags "-X main.Version=${VERSION} -X main.Build=${BUILD}"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pam-keycloak-oidc
 
-**Current version: 1.1.6**
+**Current version: 1.2.0**
 
 PAM module connecting to [Keycloak](https://www.keycloak.org/) for user authentication using OpenID Connect protocol,
 MFA (Multi-Factor Authentication) or TOTP (Time-based One-time Password) is supported.
@@ -53,7 +53,7 @@ In theory, it should work with any identity provider which supports OpenID Conne
     then make the relevant users join that group. Refer to Keycloak documents for the HOWTO.
 
 5.  Download the precompiled binary from Github, e.g. as `/opt/pam-keycloak-oidc/pam-keycloak-oidc`. In case the
-system is not amd64, compile this golang application for the appropriate architecture.
+system is not amd64 or arm64, compile this golang application for the appropriate architecture.
 
 6.  ```shell
     chmod +x /opt/pam-keycloak-oidc/pam-keycloak-oidc


### PR DESCRIPTION
My fork at [willstott101/pam-keycloak-oidc](https://github.com/willstott101/pam-keycloak-oidc) released 1.1.6 without the OTPOnly setting. When merging that feature in I bumped to 1.2.0 since it is a new feature. To save confusion I am synchronizing version numbers in this commit to 1.2.0, even though it is only the pipeline that changed in this commit.